### PR TITLE
chore: centralize component constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.DS_Store
+dist

--- a/src/components/ComponentNode.tsx
+++ b/src/components/ComponentNode.tsx
@@ -1,76 +1,98 @@
-import React, { useMemo, useState } from 'react'
-import { Handle, Position, NodeProps } from 'reactflow'
-import type { ComponentNodeData, HandleInfo } from '../types'
+import React, { useMemo, useState } from "react";
+import { Handle, Position, NodeProps } from "reactflow";
+import type { ComponentNodeData, HandleInfo } from "../types";
+import {
+  DEFAULT_HANDLE_COLOR,
+  HANDLE_PADDING,
+  DEFAULT_NODE_TITLE,
+} from "../constants";
 
 // Convert angle (deg) to normalized [top,left] within a rectangle (0..1 range)
 function angleToTopLeft(angle: number): { top: string; left: string } {
   // Place handle around a circle mapped into the node's bounding box
-  const rad = (angle * Math.PI) / 180
+  const rad = (angle * Math.PI) / 180;
   // Range [-1,1]
-  const x = Math.cos(rad)
-  const y = Math.sin(rad)
+  const x = Math.cos(rad);
+  const y = Math.sin(rad);
   // Map to [0,1] and clamp a bit to avoid clipping
-  const pad = 0.06
-  const left = ((x + 1) / 2) * (1 - 2 * pad) + pad
-  const top = ((y + 1) / 2) * (1 - 2 * pad) + pad
-  return { top: `${(top * 100).toFixed(2)}%`, left: `${(left * 100).toFixed(2)}%` }
+  const pad = HANDLE_PADDING;
+  const left = ((x + 1) / 2) * (1 - 2 * pad) + pad;
+  const top = ((y + 1) / 2) * (1 - 2 * pad) + pad;
+  return {
+    top: `${(top * 100).toFixed(2)}%`,
+    left: `${(left * 100).toFixed(2)}%`,
+  };
 }
 
-function getDefaultAngles(n: number, side: 'left' | 'right'): number[] {
-  const start = side === 'left' ? 180 : 0
-  const span = 160 // fan
-  const offset = (180 - span) / 2
-  const res: number[] = []
+function getDefaultAngles(n: number, side: "left" | "right"): number[] {
+  const start = side === "left" ? 180 : 0;
+  const span = 160; // fan
+  const offset = (180 - span) / 2;
+  const res: number[] = [];
   for (let i = 0; i < n; i++) {
-    const frac = n > 1 ? i / (n - 1) : 0.5
-    const a = start + (side === 'left' ? 1 : 1) * (frac * span - offset)
-    res.push(a)
+    const frac = n > 1 ? i / (n - 1) : 0.5;
+    const a = start + (side === "left" ? 1 : 1) * (frac * span - offset);
+    res.push(a);
   }
-  return res
+  return res;
 }
 
-export default function ComponentNode({ data, selected }: NodeProps<ComponentNodeData>) {
-  const [hover, setHover] = useState(false)
+export default function ComponentNode({
+  data,
+  selected,
+}: NodeProps<ComponentNodeData>) {
+  const [hover, setHover] = useState(false);
 
   const inputs: HandleInfo[] = useMemo(() => {
-    const arr = data.inputHandles ?? [{ id: 'in-1' }]
-    const missing = arr.filter(h => h.angle == null)
+    const arr = data.inputHandles ?? [{ id: "in-1" }];
+    const missing = arr.filter((h) => h.angle == null);
     if (missing.length) {
-      const angles = getDefaultAngles(arr.length, 'left')
-      return arr.map((h, i) => ({ ...h, angle: h.angle ?? angles[i] }))
+      const angles = getDefaultAngles(arr.length, "left");
+      return arr.map((h, i) => ({ ...h, angle: h.angle ?? angles[i] }));
     }
-    return arr
-  }, [data.inputHandles])
+    return arr;
+  }, [data.inputHandles]);
 
   const outputs: HandleInfo[] = useMemo(() => {
-    const arr = data.outputHandles ?? [{ id: 'out-1' }]
-    const missing = arr.filter(h => h.angle == null)
+    const arr = data.outputHandles ?? [{ id: "out-1" }];
+    const missing = arr.filter((h) => h.angle == null);
     if (missing.length) {
-      const angles = getDefaultAngles(arr.length, 'right')
-      return arr.map((h, i) => ({ ...h, angle: h.angle ?? angles[i] }))
+      const angles = getDefaultAngles(arr.length, "right");
+      return arr.map((h, i) => ({ ...h, angle: h.angle ?? angles[i] }));
     }
-    return arr
-  }, [data.outputHandles])
+    return arr;
+  }, [data.outputHandles]);
 
   return (
     <div
-      className={`component-node ${selected ? 'selected' : ''}`}
+      className={`component-node ${selected ? "selected" : ""}`}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
     >
-      {data.image && <img className="node-thumb" src={data.image} alt={data.title ?? 'node'} />}
-      <div className="node-title">{data.title ?? 'Node'}</div>
+      {data.image && (
+        <img
+          className="node-thumb"
+          src={data.image}
+          alt={data.title ?? DEFAULT_NODE_TITLE}
+        />
+      )}
+      <div className="node-title">{data.title ?? DEFAULT_NODE_TITLE}</div>
 
       {/* Hover card with attributes */}
       {hover && data.attrs && Object.keys(data.attrs).length > 0 && (
         <div className="hover-card">
           <table>
             <thead>
-              <tr><th colSpan={2}>Attributes</th></tr>
+              <tr>
+                <th colSpan={2}>Attributes</th>
+              </tr>
             </thead>
             <tbody>
               {Object.entries(data.attrs).map(([k, v]) => (
-                <tr key={k}><td>{k}</td><td>{v}</td></tr>
+                <tr key={k}>
+                  <td>{k}</td>
+                  <td>{v}</td>
+                </tr>
               ))}
             </tbody>
           </table>
@@ -79,35 +101,43 @@ export default function ComponentNode({ data, selected }: NodeProps<ComponentNod
 
       {/* Render input handles */}
       {inputs.map((h) => {
-        const a = h.angle ?? 180
-        const pos = angleToTopLeft(a)
+        const a = h.angle ?? 180;
+        const pos = angleToTopLeft(a);
         return (
           <Handle
             key={h.id}
             id={h.id}
             type="target"
             position={Position.Left}
-            style={{ top: pos.top, left: pos.left, borderColor: h.color ?? '#444' }}
+            style={{
+              top: pos.top,
+              left: pos.left,
+              borderColor: h.color ?? DEFAULT_HANDLE_COLOR,
+            }}
             isConnectable
           />
-        )
+        );
       })}
 
       {/* Render output handles */}
       {outputs.map((h) => {
-        const a = h.angle ?? 0
-        const pos = angleToTopLeft(a)
+        const a = h.angle ?? 0;
+        const pos = angleToTopLeft(a);
         return (
           <Handle
             key={h.id}
             id={h.id}
             type="source"
             position={Position.Right}
-            style={{ top: pos.top, left: pos.left, borderColor: h.color ?? '#444' }}
+            style={{
+              top: pos.top,
+              left: pos.left,
+              borderColor: h.color ?? DEFAULT_HANDLE_COLOR,
+            }}
             isConnectable
           />
-        )
+        );
       })}
     </div>
-  )
+  );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+// Centralized constants for node and handle styling
+export const DEFAULT_HANDLE_COLOR = "#444";
+export const HANDLE_PADDING = 0.06;
+export const DEFAULT_NODE_TITLE = "Node";


### PR DESCRIPTION
## Summary
- add shared constants for handle defaults
- use centralized constants in `ComponentNode`
- ignore `node_modules` and build output

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68a65de7fd248321b48e838072e1fdf6