### PR TITLE
Add geometry helpers and draggable CarrierHandle component

### DIFF
--- a/src/components/CarrierHandle.tsx
+++ b/src/components/CarrierHandle.tsx
@@ -1,0 +1,126 @@
+import React, {
+  useRef,
+  useCallback,
+  useMemo,
+  useEffect,
+  useState,
+} from "react";
+import { Handle } from "reactflow";
+
+import {
+  CarrierHandleProps,
+  angleToPointOnPolygon,
+  projectToAngleOnPolygon,
+  angleToLogicalPosition,
+} from "../helpers/net.helper";
+
+const CarrierHandle: React.FC<CarrierHandleProps> = ({
+  id,
+  type,
+  angle,
+  onUpdate,
+  onDragStop,
+  color = "#555",
+  opacity = 1,
+}) => {
+  const handleRef = useRef<HTMLDivElement>(null);
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  // --- SOLUTION 1: Use refs to store mutable state ---
+  const stateRef = useRef({
+    isDragging: false,
+    lastAngle: angle,
+    onUpdate,
+    onDragStop,
+  });
+
+  useEffect(() => {
+    stateRef.current.onUpdate = onUpdate;
+    stateRef.current.onDragStop = onDragStop;
+  }, [onUpdate, onDragStop]);
+
+  useEffect(() => {
+    stateRef.current.lastAngle = angle;
+  }, [angle]);
+
+  const position = useMemo(() => angleToPointOnPolygon(angle), [angle]);
+  const logicalPosition = useMemo(() => angleToLogicalPosition(angle), [angle]);
+
+  const handleMouseUp = useCallback(() => {
+    if (stateRef.current.isDragging) {
+      setIsDragging(false);
+      stateRef.current.isDragging = false;
+      stateRef.current.onDragStop?.(id, stateRef.current.lastAngle);
+    }
+  }, [id]);
+
+  const handleMouseMove = useCallback(
+    (event: MouseEvent) => {
+      if (!stateRef.current.isDragging || !nodeRef.current) return;
+
+      const nodeRect = nodeRef.current.getBoundingClientRect();
+      const localX = event.clientX - nodeRect.left;
+      const localY = event.clientY - nodeRect.top;
+      const newAngle = projectToAngleOnPolygon(localX, localY);
+
+      stateRef.current.lastAngle = newAngle;
+      stateRef.current.onUpdate(id, newAngle);
+    },
+    [id],
+  );
+
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      nodeRef.current = handleRef.current?.closest(
+        ".react-flow__node",
+      ) as HTMLDivElement;
+      if (!nodeRef.current) {
+        console.error("Unable to locate parent node (.react-flow__node)");
+        return;
+      }
+
+      setIsDragging(true);
+      stateRef.current.isDragging = true;
+
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
+    },
+    [handleMouseMove, handleMouseUp],
+  );
+
+  useEffect(() => {
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [handleMouseMove, handleMouseUp]);
+
+  return (
+    <Handle
+      ref={handleRef}
+      id={id}
+      type={type}
+      position={logicalPosition}
+      onMouseDown={handleMouseDown}
+      title="Drag to reposition this connector"
+      style={{
+        position: "absolute",
+        left: `${position.x}px`,
+        top: `${position.y}px`,
+        transform: "translate(-50%, -50%)",
+        width: 7,
+        height: 7,
+        backgroundColor: color,
+        opacity,
+        cursor: isDragging ? "grabbing" : "move",
+        zIndex: 20,
+      }}
+    />
+  );
+};
+
+export default CarrierHandle;

--- a/src/helpers/net.helper.ts
+++ b/src/helpers/net.helper.ts
@@ -1,0 +1,112 @@
+import { Position } from "reactflow";
+
+// Basic polygon geometry helpers for handle positioning
+export const NODE_CENTER = { x: 0, y: 0 };
+
+// Default square polygon around the node centre
+export const POLYGON_VERTICES = [
+  { x: -25, y: -25 },
+  { x: 25, y: -25 },
+  { x: 25, y: 25 },
+  { x: -25, y: 25 },
+];
+
+export const EDGE_PADDING_RATIO = 0.1;
+
+export interface CarrierHandleProps {
+  id: string;
+  type: "source" | "target";
+  angle: number;
+  onUpdate: (id: string, angle: number) => void;
+  onDragStop?: (id: string, angle: number) => void;
+  color?: string;
+  opacity?: number;
+}
+
+// --- Geometry Functions ---
+// Convert an angle to a point on a polygon approximated circle
+export function angleToPointOnPolygon(angle: number): { x: number; y: number } {
+  const RADIUS = 25; // adjust according to polygon or node size
+  return {
+    x: NODE_CENTER.x + RADIUS * Math.cos(angle),
+    y: NODE_CENTER.y + RADIUS * Math.sin(angle),
+  };
+}
+
+export function projectToAngleOnPolygon(x: number, y: number): number {
+  const dx = x - NODE_CENTER.x;
+  const dy = y - NODE_CENTER.y;
+  const rayDir = { x: dx, y: dy };
+  const len = Math.hypot(rayDir.x, rayDir.y);
+  if (len === 0) return 0;
+  rayDir.x /= len;
+  rayDir.y /= len;
+
+  let closestT = Infinity;
+  let found = false;
+  let intersection = { x: 0, y: 0 };
+
+  for (let i = 0; i < POLYGON_VERTICES.length; i++) {
+    const v1 = POLYGON_VERTICES[i];
+    const v2 = POLYGON_VERTICES[(i + 1) % POLYGON_VERTICES.length];
+    const edgeDir = { x: v2.x - v1.x, y: v2.y - v1.y };
+
+    const det = rayDir.x * edgeDir.y - rayDir.y * edgeDir.x;
+    if (Math.abs(det) < 1e-6) continue;
+
+    const dx = v1.x - NODE_CENTER.x;
+    const dy = v1.y - NODE_CENTER.y;
+
+    const t = (dx * edgeDir.y - dy * edgeDir.x) / det;
+    const u = (dx * rayDir.y - dy * rayDir.x) / det;
+
+    if (t >= 0 && u >= 0 && u <= 1 && t < closestT) {
+      closestT = t;
+      intersection = {
+        x: NODE_CENTER.x + t * rayDir.x,
+        y: NODE_CENTER.y + t * rayDir.y,
+      };
+      found = true;
+    }
+  }
+
+  if (!found) {
+    return 0; // fallback
+  }
+
+  const finalDx = intersection.x - NODE_CENTER.x;
+  const finalDy = intersection.y - NODE_CENTER.y;
+  let angle = Math.atan2(finalDy, finalDx);
+  if (angle < 0) angle += 2 * Math.PI;
+  return angle;
+}
+
+export function angleToLogicalPosition(angle: number): Position {
+  const deg = (angle * 180) / Math.PI;
+  if (deg >= 315 || deg < 45) return Position.Right;
+  if (deg >= 45 && deg < 135) return Position.Bottom;
+  if (deg >= 135 && deg < 225) return Position.Left;
+  return Position.Top;
+}
+
+export function getAngleForSide(
+  sideIndex: number,
+  indexOnSide: number,
+  totalOnSide: number,
+): number {
+  const v1 = POLYGON_VERTICES[sideIndex];
+  const v2 = POLYGON_VERTICES[(sideIndex + 1) % POLYGON_VERTICES.length];
+  let ratio: number = 0.5;
+  if (totalOnSide > 1) {
+    const availableRange = 1.0 - 2 * EDGE_PADDING_RATIO;
+    const step = availableRange / (totalOnSide - 1);
+    ratio = EDGE_PADDING_RATIO + indexOnSide * step;
+  }
+  const x = v1.x + ratio * (v2.x - v1.x);
+  const y = v1.y + ratio * (v2.y - v1.y);
+  const dx = x - NODE_CENTER.x;
+  const dy = y - NODE_CENTER.y;
+  let angle = Math.atan2(dy, dx);
+  if (angle < 0) angle += 2 * Math.PI;
+  return angle;
+}


### PR DESCRIPTION
## Summary
- add polygon-based geometry helpers for projecting and calculating handle angles
- introduce `CarrierHandle` component supporting drag-based repositioning

## Testing
- `npm run format`
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*
- `npm install --save-dev @vitejs/plugin-react` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a660af487c83219d436f357d1c9774