### PR TITLE
feat: support customizable node shapes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import ReactFlow, {
   MiniMap,
   Controls,
@@ -9,179 +15,224 @@ import ReactFlow, {
   Connection,
   Edge,
   Node,
-  OnSelectionChangeParams
-} from 'reactflow'
-import 'reactflow/dist/style.css'
+  OnSelectionChangeParams,
+} from "reactflow";
+import "reactflow/dist/style.css";
 
-import ComponentNode from './components/ComponentNode'
-import type { ComponentNodeData, Attrs, SavedState } from './types'
-import { saveState, loadState, clearState } from './storage'
+import ComponentNode from "./components/ComponentNode";
+import type { ComponentNodeData, Attrs, SavedState } from "./types";
+import { saveState, loadState, clearState } from "./storage";
 
-const nodeTypes = { component: ComponentNode }
+const nodeTypes = { component: ComponentNode };
 
-type Selected = { nodes: Node<ComponentNodeData>[]; edges: Edge[] }
+type Selected = { nodes: Node<ComponentNodeData>[]; edges: Edge[] };
 
 const initialNodes: Node<ComponentNodeData>[] = [
   {
-    id: 'A',
-    type: 'component',
+    id: "A",
+    type: "component",
     position: { x: 100, y: 100 },
     data: {
-      title: 'Source',
-      outputHandles: [{ id: 'a-out-1', label: 'out' }],
-      attrs: { kind: 'generator' }
+      title: "Source",
+      shape: { type: "polygon", sides: 6 },
+      outputHandles: [{ id: "a-out-1", label: "out" }],
+      attrs: { kind: "generator" },
     },
   },
   {
-    id: 'B',
-    type: 'component',
+    id: "B",
+    type: "component",
     position: { x: 420, y: 220 },
     data: {
-      title: 'Sink',
-      inputHandles: [{ id: 'b-in-1', label: 'in' }],
-      attrs: { kind: 'consumer' }
+      title: "Sink",
+      shape: { type: "circle" },
+      inputHandles: [{ id: "b-in-1", label: "in" }],
+      attrs: { kind: "consumer" },
     },
   },
-]
+];
 
-const initialEdges: Edge[] = []
+const initialEdges: Edge[] = [];
 
 function downloadBlob(filename: string, content: string) {
-  const blob = new Blob([content], { type: 'application/json' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
+  const blob = new Blob([content], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
 }
 
 export default function App() {
-  const [nodes, setNodes, onNodesChange] = useNodesState<ComponentNodeData>(initialNodes)
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
-  const [selected, setSelected] = useState<Selected>({ nodes: [], edges: [] })
-  const [attrKey, setAttrKey] = useState('')
-  const [attrValue, setAttrValue] = useState('')
+  const [nodes, setNodes, onNodesChange] =
+    useNodesState<ComponentNodeData>(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const [selected, setSelected] = useState<Selected>({ nodes: [], edges: [] });
+  const [attrKey, setAttrKey] = useState("");
+  const [attrValue, setAttrValue] = useState("");
 
   // Load state on first mount
   useEffect(() => {
-    const loaded = loadState()
+    const loaded = loadState();
     if (loaded) {
-      setNodes(loaded.nodes)
-      setEdges(loaded.edges)
+      setNodes(loaded.nodes);
+      setEdges(loaded.edges);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, []);
 
   // Auto-save on change
   useEffect(() => {
-    saveState({ nodes, edges })
-  }, [nodes, edges])
+    saveState({ nodes, edges });
+  }, [nodes, edges]);
 
-  const onConnect = useCallback((c: Connection) => setEdges((eds) => addEdge(c, eds)), [setEdges])
+  const onConnect = useCallback(
+    (c: Connection) => setEdges((eds) => addEdge(c, eds)),
+    [setEdges],
+  );
 
   const addNode = () => {
-    const id = `N${Date.now().toString(36)}`
-    setNodes(nds => nds.concat({
-      id,
-      type: 'component',
-      position: { x: 200 + Math.random() * 80, y: 120 + Math.random() * 140 },
-      data: { title: 'Node', inputHandles: [{ id: id + '-in' }], outputHandles: [{ id: id + '-out' }], attrs: {} }
-    }))
-  }
+    const id = `N${Date.now().toString(36)}`;
+    setNodes((nds) =>
+      nds.concat({
+        id,
+        type: "component",
+        position: { x: 200 + Math.random() * 80, y: 120 + Math.random() * 140 },
+        data: {
+          title: "Node",
+          inputHandles: [{ id: id + "-in" }],
+          outputHandles: [{ id: id + "-out" }],
+          attrs: {},
+        },
+      }),
+    );
+  };
 
   const addImageNode = (file: File) => {
-    const reader = new FileReader()
+    const reader = new FileReader();
     reader.onload = () => {
-      const dataUrl = reader.result as string
-      const id = `IMG${Date.now().toString(36)}`
-      setNodes(nds => nds.concat({
-        id,
-        type: 'component',
-        position: { x: 260 + Math.random() * 80, y: 160 + Math.random() * 140 },
-        data: { title: file.name, image: dataUrl, inputHandles: [{ id: id + '-in' }], outputHandles: [{ id: id + '-out' }], attrs: { file: file.name } }
-      }))
-    }
-    reader.readAsDataURL(file)
-  }
+      const dataUrl = reader.result as string;
+      const id = `IMG${Date.now().toString(36)}`;
+      setNodes((nds) =>
+        nds.concat({
+          id,
+          type: "component",
+          position: {
+            x: 260 + Math.random() * 80,
+            y: 160 + Math.random() * 140,
+          },
+          data: {
+            title: file.name,
+            image: dataUrl,
+            inputHandles: [{ id: id + "-in" }],
+            outputHandles: [{ id: id + "-out" }],
+            attrs: { file: file.name },
+          },
+        }),
+      );
+    };
+    reader.readAsDataURL(file);
+  };
 
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const importRef = useRef<HTMLInputElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const importRef = useRef<HTMLInputElement>(null);
 
-  const onSelectionChange = useCallback(({ nodes: ns, edges: es }: OnSelectionChangeParams) => {
-    setSelected({ nodes: ns as Node<ComponentNodeData>[], edges: es })
-  }, [])
+  const onSelectionChange = useCallback(
+    ({ nodes: ns, edges: es }: OnSelectionChangeParams) => {
+      setSelected({ nodes: ns as Node<ComponentNodeData>[], edges: es });
+    },
+    [],
+  );
 
   // Dimming behavior for unrelated elements when something is selected
   useEffect(() => {
-    const selectedIds = new Set(selected.nodes.map(n => n.id))
-    const relatedIds = new Set<string>()
-    selected.nodes.forEach(n => relatedIds.add(n.id))
-    edges.forEach(e => {
+    const selectedIds = new Set(selected.nodes.map((n) => n.id));
+    const relatedIds = new Set<string>();
+    selected.nodes.forEach((n) => relatedIds.add(n.id));
+    edges.forEach((e) => {
       if (selectedIds.has(e.source) || selectedIds.has(e.target)) {
-        relatedIds.add(e.source); relatedIds.add(e.target)
+        relatedIds.add(e.source);
+        relatedIds.add(e.target);
       }
-    })
+    });
 
-    setNodes(nds => nds.map(n => {
-      const isRelated = relatedIds.size > 0 ? relatedIds.has(n.id) : true
-      const opacity = relatedIds.size > 0 && !isRelated ? 0.25 : 1
-      return { ...n, style: { ...(n.style || {}), opacity } }
-    }))
+    setNodes((nds) =>
+      nds.map((n) => {
+        const isRelated = relatedIds.size > 0 ? relatedIds.has(n.id) : true;
+        const opacity = relatedIds.size > 0 && !isRelated ? 0.25 : 1;
+        return { ...n, style: { ...(n.style || {}), opacity } };
+      }),
+    );
 
-    setEdges(eds => eds.map(e => {
-      const isRelated = relatedIds.size > 0 && (relatedIds.has(e.source) && relatedIds.has(e.target))
-      const opacity = relatedIds.size > 0 && !isRelated ? 0.25 : 1
-      return { ...e, style: { ...(e.style || {}), opacity } }
-    }))
-  }, [selected, setNodes, setEdges, edges])
+    setEdges((eds) =>
+      eds.map((e) => {
+        const isRelated =
+          relatedIds.size > 0 &&
+          relatedIds.has(e.source) &&
+          relatedIds.has(e.target);
+        const opacity = relatedIds.size > 0 && !isRelated ? 0.25 : 1;
+        return { ...e, style: { ...(e.style || {}), opacity } };
+      }),
+    );
+  }, [selected, setNodes, setEdges, edges]);
 
-  const selectedNode: Node<ComponentNodeData> | null = selected.nodes.length === 1 ? selected.nodes[0] : null
+  const selectedNode: Node<ComponentNodeData> | null =
+    selected.nodes.length === 1 ? selected.nodes[0] : null;
 
   const addAttr = () => {
-    if (!selectedNode || !attrKey) return
-    const id = selectedNode.id
-    setNodes(nds => nds.map(n => {
-      if (n.id !== id) return n
-      const attrs: Attrs = { ...(n.data?.attrs || {}) }
-      attrs[attrKey] = attrValue
-      return { ...n, data: { ...(n.data || {}), attrs } }
-    }))
-    setAttrKey(''); setAttrValue('')
-  }
+    if (!selectedNode || !attrKey) return;
+    const id = selectedNode.id;
+    setNodes((nds) =>
+      nds.map((n) => {
+        if (n.id !== id) return n;
+        const attrs: Attrs = { ...(n.data?.attrs || {}) };
+        attrs[attrKey] = attrValue;
+        return { ...n, data: { ...(n.data || {}), attrs } };
+      }),
+    );
+    setAttrKey("");
+    setAttrValue("");
+  };
 
   const removeAttr = (k: string) => {
-    if (!selectedNode) return
-    const id = selectedNode.id
-    setNodes(nds => nds.map(n => {
-      if (n.id !== id) return n
-      const attrs: Attrs = { ...(n.data?.attrs || {}) }
-      delete attrs[k]
-      return { ...n, data: { ...(n.data || {}), attrs } }
-    }))
-  }
+    if (!selectedNode) return;
+    const id = selectedNode.id;
+    setNodes((nds) =>
+      nds.map((n) => {
+        if (n.id !== id) return n;
+        const attrs: Attrs = { ...(n.data?.attrs || {}) };
+        delete attrs[k];
+        return { ...n, data: { ...(n.data || {}), attrs } };
+      }),
+    );
+  };
 
-  const saveJSON = () => downloadBlob('hyflow_state.json', JSON.stringify({ nodes, edges }, null, 2))
+  const saveJSON = () =>
+    downloadBlob(
+      "hyflow_state.json",
+      JSON.stringify({ nodes, edges }, null, 2),
+    );
 
   const importJSON = (file: File) => {
-    const rd = new FileReader()
+    const rd = new FileReader();
     rd.onload = () => {
       try {
-        const parsed = JSON.parse(rd.result as string) as SavedState
-        setNodes(parsed.nodes)
-        setEdges(parsed.edges)
+        const parsed = JSON.parse(rd.result as string) as SavedState;
+        setNodes(parsed.nodes);
+        setEdges(parsed.edges);
       } catch (e) {
-        alert('Invalid JSON')
+        alert("Invalid JSON");
       }
-    }
-    rd.readAsText(file)
-  }
+    };
+    rd.readAsText(file);
+  };
 
   const clearAll = () => {
-    clearState()
-    setNodes([])
-    setEdges([])
-  }
+    clearState();
+    setNodes([]);
+    setEdges([]);
+  };
 
   return (
     <div className="page">
@@ -189,13 +240,35 @@ export default function App() {
         <div className="brand">HyFlowDashboard</div>
         <div className="actions">
           <button onClick={addNode}>+ Node</button>
-          <button onClick={() => fileInputRef.current?.click()}>+ Image Node</button>
-          <input ref={fileInputRef} type="file" accept="image/*" style={{ display: 'none' }}
-            onChange={(e) => { const f = e.target.files?.[0]; if (f) addImageNode(f); e.currentTarget.value = '' }} />
+          <button onClick={() => fileInputRef.current?.click()}>
+            + Image Node
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) addImageNode(f);
+              e.currentTarget.value = "";
+            }}
+          />
           <button onClick={saveJSON}>Export JSON</button>
-          <button onClick={() => importRef.current?.click()}>Import JSON</button>
-          <input ref={importRef} type="file" accept="application/json" style={{ display: 'none' }}
-            onChange={(e) => { const f = e.target.files?.[0]; if (f) importJSON(f); e.currentTarget.value = '' }} />
+          <button onClick={() => importRef.current?.click()}>
+            Import JSON
+          </button>
+          <input
+            ref={importRef}
+            type="file"
+            accept="application/json"
+            style={{ display: "none" }}
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) importJSON(f);
+              e.currentTarget.value = "";
+            }}
+          />
           <button onClick={clearAll}>Clear</button>
         </div>
       </header>
@@ -224,17 +297,34 @@ export default function App() {
             <>
               <div className="field">
                 <label>Title</label>
-                <input value={selectedNode.data?.title ?? ''} onChange={(e) => {
-                  const v = e.target.value
-                  setNodes(nds => nds.map(n => n.id === selectedNode.id ? ({ ...n, data: { ...(n.data || {}), title: v } }) : n))
-                }} />
+                <input
+                  value={selectedNode.data?.title ?? ""}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    setNodes((nds) =>
+                      nds.map((n) =>
+                        n.id === selectedNode.id
+                          ? { ...n, data: { ...(n.data || {}), title: v } }
+                          : n,
+                      ),
+                    );
+                  }}
+                />
               </div>
 
               <div className="field">
                 <label>Add attribute</label>
                 <div className="row">
-                  <input placeholder="key" value={attrKey} onChange={e => setAttrKey(e.target.value)} />
-                  <input placeholder="value" value={attrValue} onChange={e => setAttrValue(e.target.value)} />
+                  <input
+                    placeholder="key"
+                    value={attrKey}
+                    onChange={(e) => setAttrKey(e.target.value)}
+                  />
+                  <input
+                    placeholder="value"
+                    value={attrValue}
+                    onChange={(e) => setAttrValue(e.target.value)}
+                  />
                   <button onClick={addAttr}>Add</button>
                 </div>
               </div>
@@ -242,31 +332,66 @@ export default function App() {
               <div className="attrs-list">
                 <h4>Attributes</h4>
                 <ul>
-                  {Object.entries(selectedNode.data?.attrs || {}).map(([k, v]) => (
-                    <li key={k}><strong>{k}:</strong> {v} <button onClick={() => removeAttr(k)}>x</button></li>
-                  ))}
+                  {Object.entries(selectedNode.data?.attrs || {}).map(
+                    ([k, v]) => (
+                      <li key={k}>
+                        <strong>{k}:</strong> {v}{" "}
+                        <button onClick={() => removeAttr(k)}>x</button>
+                      </li>
+                    ),
+                  )}
                 </ul>
               </div>
 
               <div className="handles">
                 <h4>Ports</h4>
                 <div className="row">
-                  <button onClick={() => {
-                    const id = selectedNode.id + '-in-' + Math.random().toString(36).slice(2,6)
-                    setNodes(nds => nds.map(n => {
-                      if (n.id !== selectedNode.id) return n
-                      const inputHandles = [...(n.data?.inputHandles || []) , { id }]
-                      return { ...n, data: { ...(n.data || {}), inputHandles } }
-                    }))
-                  }}>+ Input</button>
-                  <button onClick={() => {
-                    const id = selectedNode.id + '-out-' + Math.random().toString(36).slice(2,6)
-                    setNodes(nds => nds.map(n => {
-                      if (n.id !== selectedNode.id) return n
-                      const outputHandles = [...(n.data?.outputHandles || []) , { id }]
-                      return { ...n, data: { ...(n.data || {}), outputHandles } }
-                    }))
-                  }}>+ Output</button>
+                  <button
+                    onClick={() => {
+                      const id =
+                        selectedNode.id +
+                        "-in-" +
+                        Math.random().toString(36).slice(2, 6);
+                      setNodes((nds) =>
+                        nds.map((n) => {
+                          if (n.id !== selectedNode.id) return n;
+                          const inputHandles = [
+                            ...(n.data?.inputHandles || []),
+                            { id },
+                          ];
+                          return {
+                            ...n,
+                            data: { ...(n.data || {}), inputHandles },
+                          };
+                        }),
+                      );
+                    }}
+                  >
+                    + Input
+                  </button>
+                  <button
+                    onClick={() => {
+                      const id =
+                        selectedNode.id +
+                        "-out-" +
+                        Math.random().toString(36).slice(2, 6);
+                      setNodes((nds) =>
+                        nds.map((n) => {
+                          if (n.id !== selectedNode.id) return n;
+                          const outputHandles = [
+                            ...(n.data?.outputHandles || []),
+                            { id },
+                          ];
+                          return {
+                            ...n,
+                            data: { ...(n.data || {}), outputHandles },
+                          };
+                        }),
+                      );
+                    }}
+                  >
+                    + Output
+                  </button>
                 </div>
               </div>
             </>
@@ -276,5 +401,5 @@ export default function App() {
         </aside>
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/CarrierHandle.tsx
+++ b/src/components/CarrierHandle.tsx
@@ -9,8 +9,8 @@ import { Handle } from "reactflow";
 
 import {
   CarrierHandleProps,
-  angleToPointOnPolygon,
-  projectToAngleOnPolygon,
+  angleToPointOnShape,
+  projectToAngleOnShape,
   angleToLogicalPosition,
 } from "../helpers/net.helper";
 
@@ -18,6 +18,7 @@ const CarrierHandle: React.FC<CarrierHandleProps> = ({
   id,
   type,
   angle,
+  shape,
   onUpdate,
   onDragStop,
   color = "#555",
@@ -44,7 +45,10 @@ const CarrierHandle: React.FC<CarrierHandleProps> = ({
     stateRef.current.lastAngle = angle;
   }, [angle]);
 
-  const position = useMemo(() => angleToPointOnPolygon(angle), [angle]);
+  const position = useMemo(
+    () => angleToPointOnShape(angle, shape),
+    [angle, shape],
+  );
   const logicalPosition = useMemo(() => angleToLogicalPosition(angle), [angle]);
 
   const handleMouseUp = useCallback(() => {
@@ -62,12 +66,12 @@ const CarrierHandle: React.FC<CarrierHandleProps> = ({
       const nodeRect = nodeRef.current.getBoundingClientRect();
       const localX = event.clientX - nodeRect.left;
       const localY = event.clientY - nodeRect.top;
-      const newAngle = projectToAngleOnPolygon(localX, localY);
+      const newAngle = projectToAngleOnShape(localX, localY, shape);
 
       stateRef.current.lastAngle = newAngle;
       stateRef.current.onUpdate(id, newAngle);
     },
-    [id],
+    [id, shape],
   );
 
   const handleMouseDown = useCallback(

--- a/src/components/ComponentNode.tsx
+++ b/src/components/ComponentNode.tsx
@@ -4,20 +4,24 @@ import React, {
   useRef,
   useEffect,
   useCallback,
-} from 'react';
+} from "react";
 import {
   Position,
   NodeProps,
   NodeToolbar,
   useReactFlow,
   useUpdateNodeInternals,
-} from 'reactflow';
-import UnitWithExponent from './UnitWithExponent';
-import styles from './componentNode.module.scss';
-import EyeIcon from './EyeIcon';
-import CarrierHandle from './CarrierHandle';
-import { ComponentNodeData, HandleInfo } from '../types';
-import { DIMMED_OPACITY, FULL_OPACITY } from '../helpers/net.helper';
+} from "reactflow";
+import UnitWithExponent from "./UnitWithExponent";
+import styles from "./componentNode.module.scss";
+import EyeIcon from "./EyeIcon";
+import CarrierHandle from "./CarrierHandle";
+import { ComponentNodeData, HandleInfo, NodeShape } from "../types";
+import {
+  DIMMED_OPACITY,
+  FULL_OPACITY,
+  clipPathForShape,
+} from "../helpers/net.helper";
 
 type ComponentNodeProps = NodeProps<ComponentNodeData>;
 
@@ -39,6 +43,7 @@ const ComponentNode: React.FC<ComponentNodeProps> = ({
     view,
     isNodeToolbar,
     fadde,
+    shape = { type: "polygon", sides: 6 } as NodeShape,
     onHandleUpdate,
     onHandleDragStop,
   } = data;
@@ -49,10 +54,12 @@ const ComponentNode: React.FC<ComponentNodeProps> = ({
   const [showToolbar, setShowToolbar] = useState(false);
 
   const getDisplayValues = useMemo(() => {
-    return view === 'results' ? table_values || {} : input_info || {};
+    return view === "results" ? table_values || {} : input_info || {};
   }, [view, table_values, input_info]);
 
-  const [pinnedAttributes, setPinnedAttributes] = useState<Record<string, boolean>>({});
+  const [pinnedAttributes, setPinnedAttributes] = useState<
+    Record<string, boolean>
+  >({});
 
   useEffect(() => {
     const initialPins: Record<string, boolean> = {};
@@ -105,18 +112,23 @@ const ComponentNode: React.FC<ComponentNodeProps> = ({
     [nodeId, onHandleDragStop],
   );
 
+  const clipPath = useMemo(() => clipPathForShape(shape), [shape]);
+
   const allHandlesToRender = useMemo(() => {
-    const processHandles = (handles: HandleInfo[], type: 'source' | 'target') => {
+    const processHandles = (
+      handles: HandleInfo[],
+      type: "source" | "target",
+    ) => {
       return handles.map((h) => ({
         ...h,
         type,
         angle: h.angle!,
-        color: h.color || '#555',
+        color: h.color || "#555",
       }));
     };
     return [
-      ...processHandles(inputHandles, 'target'),
-      ...processHandles(outputHandles, 'source'),
+      ...processHandles(inputHandles, "target"),
+      ...processHandles(outputHandles, "source"),
     ];
   }, [inputHandles, outputHandles]);
 
@@ -141,24 +153,28 @@ const ComponentNode: React.FC<ComponentNodeProps> = ({
 
   return (
     <div
-      className={styles['component-node']}
+      className={styles["component-node"]}
       style={{
         opacity:
-          fadde && !selected && view === 'results'
+          fadde && !selected && view === "results"
             ? DIMMED_OPACITY
             : FULL_OPACITY,
       }}
     >
       <div
-        className={`${styles['node-visual-wrapper']} ${selected ? styles['selected'] : ''}`}
+        className={`${styles["node-visual-wrapper"]} ${selected ? styles["selected"] : ""}`}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         data-visual-wrapper="true"
-        title={view === 'edit' ? 'Doble click to edit data' : undefined}
+        title={view === "edit" ? "Doble click to edit data" : undefined}
       >
-        <div className={styles['component-background']}>
+        <div className={styles["component-background"]} style={{ clipPath }}>
           {imageSrc && (
-            <img src={imageSrc} alt={name} className={styles['component-image']} />
+            <img
+              src={imageSrc}
+              alt={name}
+              className={styles["component-image"]}
+            />
           )}
         </div>
 
@@ -166,12 +182,13 @@ const ComponentNode: React.FC<ComponentNodeProps> = ({
           <CarrierHandle
             key={handle.id}
             id={handle.id}
-            type={handle.type as 'source' | 'target'}
+            type={handle.type as "source" | "target"}
             angle={handle.angle}
             onUpdate={handleUpdateFromChild}
             onDragStop={handleDragStopFromChild}
             color={handle.color}
             opacity={handle.opacity}
+            shape={shape}
           />
         ))}
 
@@ -207,9 +224,9 @@ const ComponentNode: React.FC<ComponentNodeProps> = ({
                             togglePinAttribute(key);
                           }}
                           className={`${styles.pinButton} ${
-                            pinnedAttributes[key] ? styles.pinned : ''
+                            pinnedAttributes[key] ? styles.pinned : ""
                           }`}
-                          title={pinnedAttributes[key] ? 'Unpin' : 'Pin'}
+                          title={pinnedAttributes[key] ? "Unpin" : "Pin"}
                         >
                           <EyeIcon isPinned={!!pinnedAttributes[key]} />
                         </button>
@@ -223,11 +240,13 @@ const ComponentNode: React.FC<ComponentNodeProps> = ({
         )}
       </div>
 
-      <div className={styles['node-info-container']}>
-        <div className={styles['component-text']}>{name}</div>
+      <div className={styles["node-info-container"]}>
+        <div className={styles["component-text"]}>{name}</div>
         <div className={styles.pinnedAttributesContainer}>
           {Object.entries(pinnedAttributes)
-            .filter(([k, pinned]) => pinned && getDisplayValues[k] !== undefined)
+            .filter(
+              ([k, pinned]) => pinned && getDisplayValues[k] !== undefined,
+            )
             .map(([k]) => (
               <div key={`pinned-${k}`} className={styles.pinnedAttribute}>
                 <span className={styles.pinnedKey}>{k}: </span>
@@ -241,4 +260,3 @@ const ComponentNode: React.FC<ComponentNodeProps> = ({
 };
 
 export default ComponentNode;
-

--- a/src/components/componentNode.module.scss
+++ b/src/components/componentNode.module.scss
@@ -44,7 +44,6 @@ $shadowColor: rgba(0, 0, 0, 0.15);
   left: 0;
   background: transparent;
   background-color: white;
-  clip-path: polygon(50% 0%, 95% 25%, 95% 75%, 50% 100%, 5% 75%, 5% 25%);
   overflow: hidden;
   z-index: 0;
 }
@@ -77,7 +76,7 @@ $shadowColor: rgba(0, 0, 0, 0.15);
   color: #444;
   text-align: center;
   width: 150px;
-  line-height: 1.0;
+  line-height: 1;
   box-sizing: border-box;
   margin-top: 2px;
   flex-shrink: 0;
@@ -221,4 +220,3 @@ $shadowColor: rgba(0, 0, 0, 0.15);
 .pinnedAttribute:hover .pinnedKey {
   display: inline;
 }
-

--- a/src/helpers/net.helper.ts
+++ b/src/helpers/net.helper.ts
@@ -1,18 +1,9 @@
 import { Position } from "reactflow";
+import { NodeShape } from "../types";
 
-// Basic polygon geometry helpers for handle positioning
+// Node center and default radius
 export const NODE_CENTER = { x: 0, y: 0 };
-
-// Hexagonal polygon around the node centre
-// Oriented with a point at the top and bottom
-export const POLYGON_VERTICES = [
-  { x: 0, y: -25 },
-  { x: 21.65, y: -12.5 },
-  { x: 21.65, y: 12.5 },
-  { x: 0, y: 25 },
-  { x: -21.65, y: 12.5 },
-  { x: -21.65, y: -12.5 },
-];
+export const DEFAULT_RADIUS = 25;
 
 export const EDGE_PADDING_RATIO = 0.1;
 
@@ -23,23 +14,87 @@ export interface CarrierHandleProps {
   id: string;
   type: "source" | "target";
   angle: number;
+  shape: NodeShape;
   onUpdate: (id: string, angle: number) => void;
   onDragStop?: (id: string, angle: number) => void;
   color?: string;
   opacity?: number;
 }
 
-// --- Geometry Functions ---
-// Convert an angle to a point on a polygon approximated circle
-export function angleToPointOnPolygon(angle: number): { x: number; y: number } {
-  const RADIUS = 25; // adjust according to polygon or node size
-  return {
-    x: NODE_CENTER.x + RADIUS * Math.cos(angle),
-    y: NODE_CENTER.y + RADIUS * Math.sin(angle),
-  };
+// Generate vertices for a regular polygon
+export function generateRegularPolygonVertices(
+  sides: number,
+  radius: number = DEFAULT_RADIUS,
+): { x: number; y: number }[] {
+  const vertices: { x: number; y: number }[] = [];
+  const step = (2 * Math.PI) / sides;
+  for (let i = 0; i < sides; i++) {
+    const angle = -Math.PI / 2 + i * step;
+    vertices.push({
+      x: NODE_CENTER.x + radius * Math.cos(angle),
+      y: NODE_CENTER.y + radius * Math.sin(angle),
+    });
+  }
+  return vertices;
 }
 
-export function projectToAngleOnPolygon(x: number, y: number): number {
+// Convert an angle to a point on the shape boundary
+export function angleToPointOnShape(
+  angle: number,
+  shape: NodeShape,
+  radius: number = DEFAULT_RADIUS,
+): { x: number; y: number } {
+  if (shape.type === "circle") {
+    return {
+      x: NODE_CENTER.x + radius * Math.cos(angle),
+      y: NODE_CENTER.y + radius * Math.sin(angle),
+    };
+  }
+  const dir = { x: Math.cos(angle), y: Math.sin(angle) };
+  const vertices = generateRegularPolygonVertices(shape.sides, radius);
+
+  let closestT = Infinity;
+  let point = { x: 0, y: 0 };
+  for (let i = 0; i < vertices.length; i++) {
+    const v1 = vertices[i];
+    const v2 = vertices[(i + 1) % vertices.length];
+    const edgeDir = { x: v2.x - v1.x, y: v2.y - v1.y };
+
+    const det = dir.x * edgeDir.y - dir.y * edgeDir.x;
+    if (Math.abs(det) < 1e-6) continue;
+
+    const dx = v1.x - NODE_CENTER.x;
+    const dy = v1.y - NODE_CENTER.y;
+
+    const t = (dx * edgeDir.y - dy * edgeDir.x) / det;
+    const u = (dx * dir.y - dy * dir.x) / det;
+
+    if (t >= 0 && u >= 0 && u <= 1 && t < closestT) {
+      closestT = t;
+      point = {
+        x: NODE_CENTER.x + t * dir.x,
+        y: NODE_CENTER.y + t * dir.y,
+      };
+    }
+  }
+  return point;
+}
+
+// Project a point to the closest angle on the shape boundary
+export function projectToAngleOnShape(
+  x: number,
+  y: number,
+  shape: NodeShape,
+  radius: number = DEFAULT_RADIUS,
+): number {
+  if (shape.type === "circle") {
+    const dx = x - NODE_CENTER.x;
+    const dy = y - NODE_CENTER.y;
+    let angle = Math.atan2(dy, dx);
+    if (angle < 0) angle += 2 * Math.PI;
+    return angle;
+  }
+
   const dx = x - NODE_CENTER.x;
   const dy = y - NODE_CENTER.y;
   const rayDir = { x: dx, y: dy };
@@ -48,13 +103,15 @@ export function projectToAngleOnPolygon(x: number, y: number): number {
   rayDir.x /= len;
   rayDir.y /= len;
 
-  let closestT = Infinity;
-  let found = false;
-  let intersection = { x: 0, y: 0 };
+  const vertices = generateRegularPolygonVertices(shape.sides, radius);
 
-  for (let i = 0; i < POLYGON_VERTICES.length; i++) {
-    const v1 = POLYGON_VERTICES[i];
-    const v2 = POLYGON_VERTICES[(i + 1) % POLYGON_VERTICES.length];
+  let closestT = Infinity;
+  let intersection = { x: 0, y: 0 };
+  let found = false;
+
+  for (let i = 0; i < vertices.length; i++) {
+    const v1 = vertices[i];
+    const v2 = vertices[(i + 1) % vertices.length];
     const edgeDir = { x: v2.x - v1.x, y: v2.y - v1.y };
 
     const det = rayDir.x * edgeDir.y - rayDir.y * edgeDir.x;
@@ -76,9 +133,7 @@ export function projectToAngleOnPolygon(x: number, y: number): number {
     }
   }
 
-  if (!found) {
-    return 0; // fallback
-  }
+  if (!found) return 0;
 
   const finalDx = intersection.x - NODE_CENTER.x;
   const finalDy = intersection.y - NODE_CENTER.y;
@@ -95,13 +150,22 @@ export function angleToLogicalPosition(angle: number): Position {
   return Position.Top;
 }
 
+// Calculate angle for a handle positioned on polygon side
 export function getAngleForSide(
   sideIndex: number,
   indexOnSide: number,
   totalOnSide: number,
+  shape: NodeShape,
+  radius: number = DEFAULT_RADIUS,
 ): number {
-  const v1 = POLYGON_VERTICES[sideIndex];
-  const v2 = POLYGON_VERTICES[(sideIndex + 1) % POLYGON_VERTICES.length];
+  if (shape.type === "circle") {
+    const step = (2 * Math.PI) / totalOnSide;
+    return indexOnSide * step;
+  }
+
+  const vertices = generateRegularPolygonVertices(shape.sides, radius);
+  const v1 = vertices[sideIndex];
+  const v2 = vertices[(sideIndex + 1) % vertices.length];
   let ratio: number = 0.5;
   if (totalOnSide > 1) {
     const availableRange = 1.0 - 2 * EDGE_PADDING_RATIO;
@@ -115,4 +179,21 @@ export function getAngleForSide(
   let angle = Math.atan2(dy, dx);
   if (angle < 0) angle += 2 * Math.PI;
   return angle;
+}
+
+// Build CSS clip-path for a given shape
+export function clipPathForShape(shape: NodeShape): string {
+  if (shape.type === "circle") {
+    return "circle(50%)";
+  }
+  const sides = shape.sides;
+  const step = (2 * Math.PI) / sides;
+  const points: string[] = [];
+  for (let i = 0; i < sides; i++) {
+    const angle = -Math.PI / 2 + i * step;
+    const x = 50 + 50 * Math.cos(angle);
+    const y = 50 + 50 * Math.sin(angle);
+    points.push(`${x}% ${y}%`);
+  }
+  return `polygon(${points.join(", ")})`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,35 +1,38 @@
-import type { Node, Edge } from 'reactflow'
+import type { Node, Edge } from "reactflow";
 
-export type Attrs = Record<string, string>
+export type Attrs = Record<string, string>;
 
 export type HandleInfo = {
-  id: string
-  angle?: number // degrees, clockwise from +X (right)
-  label?: string
-  color?: string
-}
+  id: string;
+  angle?: number; // degrees, clockwise from +X (right)
+  label?: string;
+  color?: string;
+};
+
+export type NodeShape = { type: "circle" } | { type: "polygon"; sides: number };
 
 export type ComponentNodeData = {
-  title?: string
-  name?: string
-  _originalName?: string
-  attrs?: Attrs
-  inputHandles?: HandleInfo[]
-  outputHandles?: HandleInfo[]
-  image?: string // data URL
-  imageSrc?: string
-  color?: string
-  input_info?: Record<string, unknown>
-  table_values?: Record<string, unknown>
-  pin_info?: string[]
-  view?: 'edit' | 'results'
-  isNodeToolbar?: boolean
-  fadde?: boolean
-  onHandleUpdate?: (nodeId: string, handleId: string, angle: number) => void
-  onHandleDragStop?: (nodeId: string, handleId: string, angle: number) => void
-}
+  title?: string;
+  name?: string;
+  _originalName?: string;
+  attrs?: Attrs;
+  inputHandles?: HandleInfo[];
+  outputHandles?: HandleInfo[];
+  image?: string; // data URL
+  imageSrc?: string;
+  color?: string;
+  input_info?: Record<string, unknown>;
+  table_values?: Record<string, unknown>;
+  pin_info?: string[];
+  view?: "edit" | "results";
+  isNodeToolbar?: boolean;
+  fadde?: boolean;
+  shape?: NodeShape;
+  onHandleUpdate?: (nodeId: string, handleId: string, angle: number) => void;
+  onHandleDragStop?: (nodeId: string, handleId: string, angle: number) => void;
+};
 
 export type SavedState = {
-  nodes: Node<ComponentNodeData>[]
-  edges: Edge[]
-}
+  nodes: Node<ComponentNodeData>[];
+  edges: Edge[];
+};


### PR DESCRIPTION
## Summary
- add NodeShape type to define regular polygons or circles
- compute geometry and clip paths for arbitrary shapes
- pass node shape to handles and initial nodes

## Testing
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*
- `npm install @vitejs/plugin-react` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4481b1ac83219033f25c0ad6f2b0