### PR TITLE
feat: add edge configurator component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import ReactFlow, {
 import "reactflow/dist/style.css";
 
 import ComponentNode from "./components/ComponentNode";
+import EdgeConfigurator from "./components/EdgeConfigurator";
 import type { ComponentNodeData, Attrs, SavedState } from "./types";
 import { saveState, loadState, clearState } from "./storage";
 import { fetchServerInfo } from "./api";
@@ -305,6 +306,10 @@ export default function App() {
 
         <aside className="inspector">
           <h3>Inspector</h3>
+          <EdgeConfigurator
+            nodes={nodes}
+            onAddEdge={(edge) => setEdges((eds) => eds.concat(edge))}
+          />
           {selectedNode ? (
             <>
               <div className="field">

--- a/src/components/EdgeConfigurator.tsx
+++ b/src/components/EdgeConfigurator.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from "react";
+import { Edge, MarkerType, Node } from "reactflow";
+import type { ComponentNodeData, EdgeType } from "../types";
+
+interface EdgeConfiguratorProps {
+  nodes: Node<ComponentNodeData>[];
+  onAddEdge: (edge: Edge) => void;
+}
+
+const EdgeConfigurator: React.FC<EdgeConfiguratorProps> = ({
+  nodes,
+  onAddEdge,
+}) => {
+  const [source, setSource] = useState("");
+  const [target, setTarget] = useState("");
+  const [label, setLabel] = useState("");
+  const [color, setColor] = useState("#555555");
+  const [width, setWidth] = useState(2);
+  const [dash, setDash] = useState("4 2");
+  const [type, setType] = useState<EdgeType>("smoothstep");
+  const [animated, setAnimated] = useState(false);
+
+  const add = () => {
+    if (!source || !target) return;
+    const id = `${source}-${target}-${Date.now().toString(36)}`;
+    const edge: Edge = {
+      id,
+      source,
+      target,
+      label,
+      animated,
+      type,
+      style: {
+        stroke: color,
+        strokeWidth: width,
+        strokeDasharray: dash,
+      },
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color,
+        width: 10,
+        height: 10,
+      },
+      labelStyle: { fill: color, fontWeight: 500, fontSize: "8px" },
+    };
+    onAddEdge(edge);
+    setSource("");
+    setTarget("");
+    setLabel("");
+  };
+
+  return (
+    <div>
+      <h4>Agregar arista</h4>
+      <div className="field">
+        <label>Source</label>
+        <select value={source} onChange={(e) => setSource(e.target.value)}>
+          <option value="">Seleccione</option>
+          {nodes.map((n) => (
+            <option key={n.id} value={n.id}>
+              {n.data?.title || n.id}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="field">
+        <label>Target</label>
+        <select value={target} onChange={(e) => setTarget(e.target.value)}>
+          <option value="">Seleccione</option>
+          {nodes.map((n) => (
+            <option key={n.id} value={n.id}>
+              {n.data?.title || n.id}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="field">
+        <label>Label</label>
+        <input value={label} onChange={(e) => setLabel(e.target.value)} />
+      </div>
+      <div className="field">
+        <label>Color</label>
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+        />
+      </div>
+      <div className="field">
+        <label>Grosor</label>
+        <input
+          type="number"
+          value={width}
+          onChange={(e) => setWidth(Number(e.target.value))}
+        />
+      </div>
+      <div className="field">
+        <label>Dash</label>
+        <input value={dash} onChange={(e) => setDash(e.target.value)} />
+      </div>
+      <div className="field">
+        <label>Tipo</label>
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value as EdgeType)}
+        >
+          <option value="smoothstep">smoothstep</option>
+          <option value="default">default</option>
+          <option value="straight">straight</option>
+          <option value="step">step</option>
+          <option value="simplebezier">simplebezier</option>
+        </select>
+      </div>
+      <div className="field">
+        <label>
+          <input
+            type="checkbox"
+            checked={animated}
+            onChange={(e) => setAnimated(e.target.checked)}
+          />
+          Animada
+        </label>
+      </div>
+      <button onClick={add}>Crear Arista</button>
+    </div>
+  );
+};
+
+export default EdgeConfigurator;

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,3 +36,10 @@ export type SavedState = {
   nodes: Node<ComponentNodeData>[];
   edges: Edge[];
 };
+
+export type EdgeType =
+  | "smoothstep"
+  | "default"
+  | "straight"
+  | "step"
+  | "simplebezier";


### PR DESCRIPTION
## Summary
- add EdgeConfigurator component to create fully customizable edges
- expose EdgeType union for custom edge types and wire configurator into inspector

## Testing
- `npm run format`
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*
- `npm install --save-dev @vitejs/plugin-react` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af8b6fc3b08321ad9180fa69e06105