### PR TITLE
Add node shape customization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,6 +111,7 @@ export default function App() {
         position: { x: 200 + Math.random() * 80, y: 120 + Math.random() * 140 },
         data: {
           title: "Node",
+          shape: { type: "polygon", sides: 6 },
           inputHandles: [{ id: id + "-in" }],
           outputHandles: [{ id: id + "-out" }],
           attrs: {},
@@ -135,6 +136,7 @@ export default function App() {
           data: {
             title: file.name,
             image: dataUrl,
+            shape: { type: "polygon", sides: 6 },
             inputHandles: [{ id: id + "-in" }],
             outputHandles: [{ id: id + "-out" }],
             attrs: { file: file.name },
@@ -327,6 +329,68 @@ export default function App() {
                     );
                   }}
                 />
+              </div>
+
+              <div className="field">
+                <label>Shape</label>
+                <div className="row">
+                  <select
+                    value={selectedNode.data?.shape?.type || "polygon"}
+                    onChange={(e) => {
+                      const type = e.target.value as "circle" | "polygon";
+                      setNodes((nds) =>
+                        nds.map((n) => {
+                          if (n.id !== selectedNode.id) return n;
+                          const shape =
+                            type === "circle"
+                              ? { type: "circle" }
+                              : {
+                                  type: "polygon",
+                                  sides:
+                                    n.data?.shape?.type === "polygon"
+                                      ? n.data.shape.sides
+                                      : 6,
+                                };
+                          return { ...n, data: { ...(n.data || {}), shape } };
+                        }),
+                      );
+                    }}
+                  >
+                    <option value="circle">Circle</option>
+                    <option value="polygon">Polygon</option>
+                  </select>
+                  {(selectedNode.data?.shape?.type || "polygon") ===
+                    "polygon" && (
+                    <input
+                      type="number"
+                      min={3}
+                      value={
+                        selectedNode.data?.shape?.type === "polygon"
+                          ? selectedNode.data.shape.sides
+                          : 6
+                      }
+                      onChange={(e) => {
+                        const sides = Math.max(
+                          3,
+                          parseInt(e.target.value) || 3,
+                        );
+                        setNodes((nds) =>
+                          nds.map((n) =>
+                            n.id === selectedNode.id
+                              ? {
+                                  ...n,
+                                  data: {
+                                    ...(n.data || {}),
+                                    shape: { type: "polygon", sides },
+                                  },
+                                }
+                              : n,
+                          ),
+                        );
+                      }}
+                    />
+                  )}
+                </div>
               </div>
 
               <div className="field">

--- a/src/components/ComponentNode.tsx
+++ b/src/components/ComponentNode.tsx
@@ -114,6 +114,10 @@ const ComponentNode: React.FC<ComponentNodeProps> = ({
 
   const clipPath = useMemo(() => clipPathForShape(shape), [shape]);
 
+  useEffect(() => {
+    updateNodeInternals(nodeId);
+  }, [shape, nodeId, updateNodeInternals]);
+
   const allHandlesToRender = useMemo(() => {
     const processHandles = (
       handles: HandleInfo[],


### PR DESCRIPTION
## Summary
- add UI to select node shape (circle or polygon with adjustable sides)
- ensure new nodes default to hexagonal polygons
- update node internals when shape changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*
- `npm install --no-save @vitejs/plugin-react` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af8ce008b48321af974ea2007ac973