### PR TITLE
Add image search when creating nodes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import "reactflow/dist/style.css";
 
 import ComponentNode from "./components/ComponentNode";
 import EdgeConfigurator from "./components/EdgeConfigurator";
+import ImageSearch from "./components/ImageSearch";
 import type { ComponentNodeData, Attrs, SavedState } from "./types";
 import { saveState, loadState, clearState } from "./storage";
 import { fetchServerInfo } from "./api";
@@ -74,6 +75,7 @@ export default function App() {
   const [attrKey, setAttrKey] = useState("");
   const [attrValue, setAttrValue] = useState("");
   const [serverInfo, setServerInfo] = useState<string>("");
+  const [showImageSearch, setShowImageSearch] = useState(false);
 
   // Load state on first mount
   useEffect(() => {
@@ -135,7 +137,7 @@ export default function App() {
           },
           data: {
             title: file.name,
-            image: dataUrl,
+            imageSrc: dataUrl,
             shape: { type: "polygon", sides: 6 },
             inputHandles: [{ id: id + "-in" }],
             outputHandles: [{ id: id + "-out" }],
@@ -145,6 +147,28 @@ export default function App() {
       );
     };
     reader.readAsDataURL(file);
+  };
+
+  const addImageNodeFromUrl = (src: string, label: string) => {
+    const id = `IMG${Date.now().toString(36)}`;
+    setNodes((nds) =>
+      nds.concat({
+        id,
+        type: "component",
+        position: {
+          x: 260 + Math.random() * 80,
+          y: 160 + Math.random() * 140,
+        },
+        data: {
+          title: label,
+          imageSrc: src,
+          shape: { type: "polygon", sides: 6 },
+          inputHandles: [{ id: id + "-in" }],
+          outputHandles: [{ id: id + "-out" }],
+          attrs: {},
+        },
+      }),
+    );
   };
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -258,6 +282,9 @@ export default function App() {
           <button onClick={() => fileInputRef.current?.click()}>
             + Image Node
           </button>
+          <button onClick={() => setShowImageSearch((s) => !s)}>
+            Search Image
+          </button>
           <input
             ref={fileInputRef}
             type="file"
@@ -287,6 +314,15 @@ export default function App() {
           <button onClick={clearAll}>Clear</button>
         </div>
       </header>
+
+      {showImageSearch && (
+        <ImageSearch
+          onSelect={(url, label) => {
+            addImageNodeFromUrl(url, label);
+            setShowImageSearch(false);
+          }}
+        />
+      )}
 
       <div className="content">
         <div className="canvas">

--- a/src/api.ts
+++ b/src/api.ts
@@ -7,3 +7,31 @@ export async function fetchServerInfo(): Promise<any> {
   }
   return res.json();
 }
+
+export interface PixabayImage {
+  id: number;
+  previewURL: string;
+  largeImageURL: string;
+  tags: string;
+}
+
+export async function searchImages(query: string): Promise<PixabayImage[]> {
+  const key = import.meta.env.VITE_PIXABAY_KEY;
+  if (!key) {
+    throw new Error("Missing Pixabay API key");
+  }
+  const url = `https://pixabay.com/api/?key=${key}&q=${encodeURIComponent(
+    query,
+  )}&image_type=illustration&per_page=12&lang=en&category=computer`; // filter for tech icons
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to search images: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.hits.map((hit: any) => ({
+    id: hit.id,
+    previewURL: hit.previewURL,
+    largeImageURL: hit.largeImageURL,
+    tags: hit.tags,
+  }));
+}

--- a/src/components/ComponentNode.tsx
+++ b/src/components/ComponentNode.tsx
@@ -34,6 +34,7 @@ const ComponentNode: React.FC<ComponentNodeProps> = ({
   const {
     name,
     _originalName,
+    image,
     imageSrc,
     inputHandles = [],
     outputHandles = [],
@@ -173,9 +174,9 @@ const ComponentNode: React.FC<ComponentNodeProps> = ({
         title={view === "edit" ? "Doble click to edit data" : undefined}
       >
         <div className={styles["component-background"]} style={{ clipPath }}>
-          {imageSrc && (
+          {(imageSrc || image) && (
             <img
-              src={imageSrc}
+              src={imageSrc || image}
               alt={name}
               className={styles["component-image"]}
             />

--- a/src/components/ImageSearch.tsx
+++ b/src/components/ImageSearch.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import { searchImages, PixabayImage } from "../api";
+
+type ImageSearchProps = {
+  onSelect: (url: string, label: string) => void;
+};
+
+const ImageSearch: React.FC<ImageSearchProps> = ({ onSelect }) => {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<PixabayImage[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!query) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const imgs = await searchImages(query);
+      setResults(imgs);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="image-search-panel">
+      <form onSubmit={handleSearch} className="row">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Buscar imagen..."
+        />
+        <button type="submit" disabled={loading}>
+          {loading ? "Buscando..." : "Buscar"}
+        </button>
+      </form>
+      {error && <div className="error">{error}</div>}
+      <div className="image-results">
+        {results.map((img) => (
+          <img
+            key={img.id}
+            src={img.previewURL}
+            alt={img.tags}
+            onClick={() => onSelect(img.largeImageURL, img.tags)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ImageSearch;

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,5 +1,12 @@
-declare module '*.module.scss' {
+declare module "*.module.scss" {
   const classes: { [key: string]: string };
   export default classes;
 }
 
+interface ImportMetaEnv {
+  readonly VITE_PIXABAY_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -25,6 +25,7 @@ body {
   display: grid;
   grid-template-rows: 56px 1fr;
   height: 100%;
+  position: relative;
 }
 .topbar {
   display: flex;
@@ -338,4 +339,39 @@ body {
 
 .toolbarContent table tbody tr:last-child td {
   border-bottom: none;
+}
+
+.image-search-panel {
+  position: absolute;
+  top: 56px;
+  left: 0;
+  right: 0;
+  background: #0b1220;
+  border-bottom: 1px solid #1f2937;
+  padding: 8px;
+  z-index: 20;
+}
+
+.image-search-panel .row {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.image-results {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.image-results img {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  border: 1px solid #374151;
+  border-radius: 4px;
+  background: #1f2937;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- allow searching Pixabay for images when adding nodes
- new ImageSearch panel and API helper
- component nodes now display uploaded or remote images

## Testing
- `npm run format`
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*
- `npm install -D @vitejs/plugin-react` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af8f81870c8321be02ff5c375443f6