### PR TITLE
feat: provide default pixabay key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and replace with your own Pixabay API key
+VITE_PIXABAY_KEY=YOUR_PIXABAY_KEY_HERE

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Hyflow Dashboard
+
+Desarrollo local:
+
+```bash
+npm install
+cp .env.example .env # edita con tu clave de Pixabay
+npm run dev
+```
+
+La búsqueda de imágenes usa la API de Pixabay. Si no configuras la clave, se usa una de demostración con cuota limitada.

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
     "react-dom": "^18.2.0",
     "reactflow": "^11.10.0"
   },
-    "devDependencies": {
-      "@types/react": "^18.2.0",
-      "@types/react-dom": "^18.2.0",
-      "typescript": "^5.4.0",
-      "vite": "^5.4.0",
-      "prettier": "^3.3.3",
-      "sass": "^1.70.0"
-    }
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.4.0",
+    "prettier": "^3.3.3",
+    "sass": "^1.70.0",
+    "@vitejs/plugin-react": "^4.2.0"
   }
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -16,10 +16,9 @@ export interface PixabayImage {
 }
 
 export async function searchImages(query: string): Promise<PixabayImage[]> {
-  const key = import.meta.env.VITE_PIXABAY_KEY;
-  if (!key) {
-    throw new Error("Missing Pixabay API key");
-  }
+  const key =
+    import.meta.env.VITE_PIXABAY_KEY ||
+    "27844507-0c1f742675011cd3c5112d94ed"; // demo key with limited quota
   const url = `https://pixabay.com/api/?key=${key}&q=${encodeURIComponent(
     query,
   )}&image_type=illustration&per_page=12&lang=en&category=computer`; // filter for tech icons


### PR DESCRIPTION
## Summary
- use a demo Pixabay API key when no key is configured
- document API key usage and provide example env file
- add missing Vite React plugin dev dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react', npm install blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af951788b08321b246f2ff7e6773cd