### PR TITLE
Use Flickr feed for image search

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -8,29 +8,27 @@ export async function fetchServerInfo(): Promise<any> {
   return res.json();
 }
 
-export interface PixabayImage {
-  id: number;
+export interface ImageResult {
+  id: string;
   previewURL: string;
   largeImageURL: string;
   tags: string;
 }
 
-export async function searchImages(query: string): Promise<PixabayImage[]> {
-  const key =
-    import.meta.env.VITE_PIXABAY_KEY ||
-    "27844507-0c1f742675011cd3c5112d94ed"; // demo key with limited quota
-  const url = `https://pixabay.com/api/?key=${key}&q=${encodeURIComponent(
-    query,
-  )}&image_type=illustration&per_page=12&lang=en&category=computer`; // filter for tech icons
+// Searches public Flickr images by tag. This endpoint is free and requires no API key.
+export async function searchImages(query: string): Promise<ImageResult[]> {
+  const url =
+    "https://www.flickr.com/services/feeds/photos_public.gne" +
+    `?format=json&nojsoncallback=1&tags=${encodeURIComponent(query)}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to search images: ${res.status}`);
   }
   const data = await res.json();
-  return data.hits.map((hit: any) => ({
-    id: hit.id,
-    previewURL: hit.previewURL,
-    largeImageURL: hit.largeImageURL,
-    tags: hit.tags,
+  return data.items.map((item: any, idx: number) => ({
+    id: item.link || String(idx),
+    previewURL: item.media.m,
+    largeImageURL: item.media.m.replace("_m.", "_b."),
+    tags: item.title,
   }));
 }

--- a/src/components/ImageSearch.tsx
+++ b/src/components/ImageSearch.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { searchImages, PixabayImage } from "../api";
+import { searchImages, ImageResult } from "../api";
 
 type ImageSearchProps = {
   onSelect: (url: string, label: string) => void;
@@ -7,7 +7,7 @@ type ImageSearchProps = {
 
 const ImageSearch: React.FC<ImageSearchProps> = ({ onSelect }) => {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<PixabayImage[]>([]);
+  const [results, setResults] = useState<ImageResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 


### PR DESCRIPTION
## Summary
- replace Pixabay integration with Flickr public feed for image search
- adjust ImageSearch component to handle new result structure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*


------
https://chatgpt.com/codex/tasks/task_e_68af96562ef88321817b1c37d75f39ce